### PR TITLE
Timer pause method call moved to different method

### DIFF
--- a/Assets/Scripts/LogoHaalariin/LogoHaalariinLogic.cs
+++ b/Assets/Scripts/LogoHaalariin/LogoHaalariinLogic.cs
@@ -63,6 +63,7 @@ public class LogoHaalariinLogic : MonoBehaviour, IMinigameEnder {
 
     // win / lose in other cases except time running out 
     public async void EndGame(bool win) {
+        timer.StopTimerProgression();
         if (win) {
             logoUpdater.startRotateLogoAnimation();
         } else {
@@ -73,11 +74,10 @@ public class LogoHaalariinLogic : MonoBehaviour, IMinigameEnder {
     }
 
     public void endGame() {
-        timer.StopTimerProgression();
         if (this.logo == this.haalari) {
             EndGame(true);
         } else {
-            EndGame(false); 
+            EndGame(false);
         }
     }
     public async void timesUp() {


### PR DESCRIPTION
Behold how the timer is stopped in EndGame, which is called in most cases when the minigame result is determined.